### PR TITLE
Implement `Run`, and introduce `Scorer`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           check-latest: true
 
       - name: Evaluate
-        run: go test -v -shuffle on -run TestEval ./...
+        run: go test -json -run TestEval ./... | jq 'select(.Test != null and .Action == "output" and (.Output | contains("score"))) | del(.Action)'
 
   lint:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ cover:
 
 .PHONY: evaluate
 evaluate:
-	go test -json -run TestEval ./... | jq 'select(.Test != null and (.Action == "pass" or .Action == "fail" or .Action == "skip"))'
+	go test -json -run TestEval ./... | jq 'select(.Test != null and .Action == "output" and (.Output | contains("score"))) | del(.Action)'
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Does your company depend on this project? [Contact me at markus@maragu.dk](mailt
 
 ## Usage
 
-This test will only run with `go test -run TestEval ./...` because of the `eval.SkipIfNotEvaluating(t)` call:
+This test will only run with `go test -run TestEval ./...` and otherwise be skipped:
 
 ```go
 package examples_test
@@ -33,13 +33,28 @@ import (
 // TestEvalPrompt evaluates the Prompt method.
 // All evals must be prefixed with "TestEval".
 func TestEvalPrompt(t *testing.T) {
-	// Skip the test if not evaluating, by running the test suite with "go test -run TestEval".
-	eval.SkipIfNotEvaluating(t)
-
-	t.Run("answers with a pong", func(t *testing.T) {
+	// Evals only run if "go test" is being run with "-test.run=TestEval", e.g.: "go test -test.run=TestEval ./..."
+	eval.Run(t, "answers with a pong", func(e *eval.E) {
+		// Initialize our intensely powerful LLM.
 		llm := &llm{response: "plong"}
-		response := llm.Prompt("ping")
-		eval.Similarity(t, "pong", response, eval.LevenshteinEvaluator(0.8))
+
+		// Send our input to the LLM and get an output back.
+		input := "ping"
+		output := llm.Prompt(input)
+
+		// Create a sample to pass to the scorer.
+		sample := eval.Sample{
+			Expected: "pong",
+			Input:    input,
+			Output:   output,
+		}
+
+		// Score the sample using the Levenshtein distance scorer.
+		// The scorer is created inline, but for scorers that need more setup, this can be done elsewhere.
+		score := e.Score(sample, eval.LevenshteinDistanceScorer())
+
+		// Log the score to stdout.
+		e.Log(score)
 	})
 }
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -2,52 +2,14 @@ package eval
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/agnivade/levenshtein"
 )
 
-type helper interface {
-	Helper()
-}
-
-type skipper interface {
-	helper
-	Skip(args ...any)
-}
-
-// SkipIfNotEvaluating skips the test if "go test" is not being run with "-test.run=TestEval".
-func SkipIfNotEvaluating(t skipper) {
-	t.Helper()
-
-	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, "-test.run=TestEval") {
-			return
-		}
-	}
-
-	t.Skip("skipping eval")
-}
-
-type errorer interface {
-	helper
-	Errorf(format string, args ...any)
-}
-
-// SimilarityEvaluator is a function that evaluates the similarity between two strings,
-// returning true if they are similar enough, and false otherwise.
-// It's typically used in a closure.
-type SimilarityEvaluator = func(s1, s2 string) bool
-
-// Similarity compares two strings according to the given [SimilarityEvaluator],
-// and fails the test if the evaluator returns false.
-func Similarity(t errorer, s1, s2 string, se SimilarityEvaluator) {
-	t.Helper()
-
-	if !se(s1, s2) {
-		t.Errorf(`"%v" and "%v" are dissimilar`, s1, s2)
-	}
+type Sample struct {
+	Expected string
+	Input    string
+	Output   string
 }
 
 // Score between 0 and 1.
@@ -64,17 +26,18 @@ func (s Score) String() string {
 	return fmt.Sprintf("%.2f", float64(s))
 }
 
-// LevenshteinEvaluator returns a [SimilarityEvaluator] that uses the [LevenshteinDistanceScore] to compare strings,
-// and returns true if the similarity [Score] is greater than or equal to the given threshold.
-func LevenshteinEvaluator(threshold Score) SimilarityEvaluator {
-	threshold.IsValid()
+// Scorer produces a [Score] for a [Sample].
+type Scorer = func(s Sample) Score
 
-	return func(s1, s2 string) bool {
-		return LevenshteinDistanceScore(s1, s2) >= threshold
+// LevenshteinDistanceScorer returns a [Scorer] that uses the [LevenshteinDistanceScore] to compare strings.
+func LevenshteinDistanceScorer() Scorer {
+	return func(s Sample) Score {
+		return LevenshteinDistanceScore(s.Expected, s.Output)
 	}
 }
 
-// LevenshteinDistanceScore computes a similarity [Score] between two strings using the levenshtein distance.
+// LevenshteinDistanceScore computes a [Score] between two strings using the levenshtein distance.
+// A score of 1 means the strings are equal, and 0 means they are completely different.
 // Uses https://github.com/agnivade/levenshtein
 func LevenshteinDistanceScore(s1, s2 string) Score {
 	if s1 == s2 {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -1,36 +1,13 @@
 package eval_test
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
 	"maragu.dev/is"
+
 	"maragu.dev/llm/eval"
 )
-
-func TestSkipIfNotEvaluating(t *testing.T) {
-	t.Run("skips if called like a regular test", func(t *testing.T) {
-		mt := &mockT{}
-		eval.SkipIfNotEvaluating(mt)
-		is.True(t, mt.skipped)
-	})
-}
-
-func TestSimilarity(t *testing.T) {
-	t.Run("fails the test if the score is lower than a threshold", func(t *testing.T) {
-		mt := &mockT{}
-		eval.Similarity(mt, "a", "b", eval.LevenshteinEvaluator(0.5))
-		is.True(t, mt.failed)
-		is.Equal(t, `"a" and "b" are dissimilar`, mt.message)
-	})
-
-	t.Run("does not fail the test if the score is equal to the expected", func(t *testing.T) {
-		mt := &mockT{}
-		eval.Similarity(mt, "a", "a", eval.LevenshteinEvaluator(1))
-		is.True(t, !mt.failed)
-	})
-}
 
 func TestLevenshteinDistanceScore(t *testing.T) {
 	tests := []struct {
@@ -53,21 +30,4 @@ func TestLevenshteinDistanceScore(t *testing.T) {
 			is.True(t, math.Abs(float64(tt.score-score)) < 0.01)
 		})
 	}
-}
-
-type mockT struct {
-	failed  bool
-	message string
-	skipped bool
-}
-
-func (t *mockT) Helper() {}
-
-func (t *mockT) Errorf(format string, args ...any) {
-	t.failed = true
-	t.message = fmt.Sprintf(format, args...)
-}
-
-func (t *mockT) Skip(args ...any) {
-	t.skipped = true
 }

--- a/eval/run.go
+++ b/eval/run.go
@@ -1,0 +1,66 @@
+package eval
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+type helper interface {
+	Helper()
+}
+
+type skipper interface {
+	helper
+	SkipNow()
+}
+
+// skipIfNotEvaluating skips the test if "go test" is not being run with "-test.run=TestEval".
+// Returns whether the test was skipped.
+func skipIfNotEvaluating(t skipper) {
+	t.Helper()
+
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, "-test.run=TestEval") {
+			return
+		}
+	}
+
+	t.SkipNow()
+}
+
+type runnerSkipper interface {
+	skipper
+	Run(name string, f func(t *testing.T)) bool
+}
+
+// Run an evaluation.
+// Behaves similar to [testing.T.Run], except it skips the test if "go test" is not being run with "-test.run=TestEval".
+// The evaluation function [f] is passed an [E] to help with scoring, logging, etc.
+func Run(t runnerSkipper, name string, f func(e *E)) {
+	t.Helper()
+
+	t.Run(name, func(t *testing.T) {
+		skipIfNotEvaluating(t)
+
+		f(&E{T: t})
+	})
+}
+
+type E struct {
+	T *testing.T
+}
+
+// Score a [Sample] using a [Scorer], making sure the score is valid.
+// This is just a convenience method to make it easier to swap out scorers.
+func (e *E) Score(s Sample, scorer Scorer) Score {
+	score := scorer(s)
+	score.IsValid()
+	return score
+}
+
+// Log a [Score].
+func (e *E) Log(s Score) {
+	e.T.Helper()
+	e.T.Logf("score=%v", s)
+}

--- a/eval/run_test.go
+++ b/eval/run_test.go
@@ -1,0 +1,16 @@
+package eval_test
+
+import (
+	"testing"
+
+	"maragu.dev/llm/eval"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("skips if called like a regular test", func(t *testing.T) {
+		eval.Run(t, "some eval", func(e *eval.E) {
+			// This will not be reached because the test is skipped
+			e.T.FailNow()
+		})
+	})
+}

--- a/internal/examples/prompt_test.go
+++ b/internal/examples/prompt_test.go
@@ -9,13 +9,28 @@ import (
 // TestEvalPrompt evaluates the Prompt method.
 // All evals must be prefixed with "TestEval".
 func TestEvalPrompt(t *testing.T) {
-	// Skip the test if not evaluating, by running the test suite with "go test -run TestEval".
-	eval.SkipIfNotEvaluating(t)
-
-	t.Run("answers with a pong", func(t *testing.T) {
+	// Evals only run if "go test" is being run with "-test.run=TestEval", e.g.: "go test -test.run=TestEval ./..."
+	eval.Run(t, "answers with a pong", func(e *eval.E) {
+		// Initialize our intensely powerful LLM.
 		llm := &llm{response: "plong"}
-		response := llm.Prompt("ping")
-		eval.Similarity(t, "pong", response, eval.LevenshteinEvaluator(0.8))
+
+		// Send our input to the LLM and get an output back.
+		input := "ping"
+		output := llm.Prompt(input)
+
+		// Create a sample to pass to the scorer.
+		sample := eval.Sample{
+			Expected: "pong",
+			Input:    input,
+			Output:   output,
+		}
+
+		// Score the sample using the Levenshtein distance scorer.
+		// The scorer is created inline, but for scorers that need more setup, this can be done elsewhere.
+		score := e.Score(sample, eval.LevenshteinDistanceScorer())
+
+		// Log the score to stdout.
+		e.Log(score)
 	})
 }
 


### PR DESCRIPTION
Instead of having evaluators that fail or pass the test, have a `Scorer` that outputs a `Score` that can be logged (and later tracked).

Also, simplified running evals using `eval.Run`.