### PR TITLE
Add `LexicalSimilarityScorer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func TestEvalPrompt(t *testing.T) {
 
 		// Score the sample using the Levenshtein distance scorer.
 		// The scorer is created inline, but for scorers that need more setup, this can be done elsewhere.
-		result := e.Score(sample, eval.LevenshteinDistanceScorer())
+		result := e.Score(sample, eval.LexicalSimilarityScorer(eval.LevenshteinDistance))
 
 		// Log the sample, result, and timing information.
 		e.Log(sample, result)

--- a/internal/examples/hi_test.go
+++ b/internal/examples/hi_test.go
@@ -52,7 +52,7 @@ func TestEvalLLMs(t *testing.T) {
 				Expected: test.expected,
 			}
 
-			result := e.Score(sample, eval.LevenshteinDistanceScorer())
+			result := e.Score(sample, eval.LexicalSimilarityScorer(eval.LevenshteinDistance))
 
 			e.Log(sample, result)
 		})

--- a/internal/examples/mock_test.go
+++ b/internal/examples/mock_test.go
@@ -27,7 +27,7 @@ func TestEvalPrompt(t *testing.T) {
 
 		// Score the sample using the Levenshtein distance scorer.
 		// The scorer is created inline, but for scorers that need more setup, this can be done elsewhere.
-		result := e.Score(sample, eval.LevenshteinDistanceScorer())
+		result := e.Score(sample, eval.LexicalSimilarityScorer(eval.LevenshteinDistance))
 
 		// Log the sample, result, and timing information.
 		e.Log(sample, result)


### PR DESCRIPTION
Use this as a top-level scorer instead of `eval.LevenshteinDistanceScorer` and `eval.ExactMatchScorer`, and take the two similarity metric functions as parameters instead.