### PR TITLE
Add `Completer` interface

### DIFF
--- a/openai.go
+++ b/openai.go
@@ -1,12 +1,18 @@
 package llm
 
 import (
-	"io"
+	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+)
+
+const (
+	ModelGPT4o     = ChatModel(openai.ChatModelGPT4o)
+	ModelGPT4oMini = ChatModel(openai.ChatModelGPT4oMini)
 )
 
 type OpenAIClient struct {
@@ -22,7 +28,7 @@ type NewOpenAIClientOptions struct {
 
 func NewOpenAIClient(opts NewOpenAIClientOptions) *OpenAIClient {
 	if opts.Log == nil {
-		opts.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+		opts.Log = slog.New(slog.DiscardHandler)
 	}
 
 	var clientOpts []option.RequestOption
@@ -42,4 +48,77 @@ func NewOpenAIClient(opts NewOpenAIClientOptions) *OpenAIClient {
 		Client: openai.NewClient(clientOpts...),
 		log:    opts.Log,
 	}
+}
+
+// Complete satisfies [Completer].
+func (c *OpenAIClient) Complete(ctx context.Context, p Prompt) CompletionResponse {
+	var messages []openai.ChatCompletionMessageParamUnion
+	for _, m := range p.Messages {
+		switch m.Role {
+		case MessageRoleUser:
+			var parts []openai.ChatCompletionContentPartUnionParam
+			for _, part := range m.Parts {
+				switch part.Type {
+				case MessagePartTypeText:
+					parts = append(parts, openai.TextPart(part.Text()))
+				default:
+					panic("not implemented")
+				}
+			}
+			messages = append(messages, openai.UserMessageParts(parts...))
+
+		default:
+			panic("not implemented")
+		}
+	}
+
+	params := openai.ChatCompletionNewParams{
+		Messages: openai.F(messages),
+		Model:    openai.F(openai.ChatModel(p.Model)),
+	}
+
+	if p.Temperature != nil {
+		params.Temperature = openai.F(*p.Temperature)
+	}
+
+	stream := c.Client.Chat.Completions.NewStreaming(ctx, params)
+
+	return NewCompletionResponse(func(yield func(MessagePart, error) bool) {
+		defer func() {
+			if err := stream.Close(); err != nil {
+				c.log.Info("Error closing stream", "error", err)
+			}
+		}()
+
+		var acc openai.ChatCompletionAccumulator
+		for stream.Next() {
+			chunk := stream.Current()
+			acc.AddChunk(chunk)
+
+			if _, ok := acc.JustFinishedContent(); ok {
+				break
+			}
+
+			if _, ok := acc.JustFinishedToolCall(); ok {
+				continue
+				// TODO handle tool call
+				// println("Tool call stream finished:", tool.Index, tool.Name, tool.Arguments)
+			}
+
+			if refusal, ok := acc.JustFinishedRefusal(); ok {
+				yield(MessagePart{}, fmt.Errorf("refusal: %v", refusal))
+				return
+			}
+
+			if len(chunk.Choices) > 0 {
+				if !yield(TextMessagePart(chunk.Choices[0].Delta.Content), nil) {
+					return
+				}
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			yield(MessagePart{}, err)
+		}
+	})
 }

--- a/prompt.go
+++ b/prompt.go
@@ -1,0 +1,91 @@
+package llm
+
+import (
+	"context"
+	"io"
+	"iter"
+	"strings"
+)
+
+// ChatModel identified by name.
+type ChatModel string
+
+// Prompt for a chat model.
+type Prompt struct {
+	Model       ChatModel
+	Messages    []Message
+	Temperature *float64
+}
+
+// MessageRole for [Message].
+type MessageRole string
+
+const (
+	MessageRoleUser      MessageRole = "user"
+	MessageRoleAssistant MessageRole = "assistant"
+)
+
+// MessagePartType for [MessagePart].
+type MessagePartType string
+
+const (
+	MessagePartTypeText MessagePartType = "text"
+)
+
+type Message struct {
+	Role  MessageRole
+	Parts []MessagePart
+}
+
+type MessagePart struct {
+	Type MessagePartType
+	Data io.Reader
+	text *string
+}
+
+func (m MessagePart) Text() string {
+	if m.Type != MessagePartTypeText {
+		panic("not text type")
+	}
+	if m.text != nil {
+		return *m.text
+	}
+	text, err := io.ReadAll(m.Data)
+	if err != nil {
+		panic("error reading text: " + err.Error())
+	}
+	return string(text)
+}
+
+func TextMessagePart(text string) MessagePart {
+	return MessagePart{
+		Type: MessagePartTypeText,
+		Data: strings.NewReader(text),
+		text: Ptr(text),
+	}
+}
+
+// Completer is satisfied by clients supporting chat completion.
+// Streaming chat completion is preferred where possible, so that methods on [CompletionResponse] like [CompletionResponse.Parts]
+// can be used to stream the response.
+type Completer interface {
+	Complete(ctx context.Context, p Prompt) CompletionResponse
+}
+
+type CompletionResponse struct {
+	partsFunc iter.Seq2[MessagePart, error]
+}
+
+func (c CompletionResponse) Parts() iter.Seq2[MessagePart, error] {
+	return c.partsFunc
+}
+
+func NewCompletionResponse(partsFunc iter.Seq2[MessagePart, error]) CompletionResponse {
+	return CompletionResponse{
+		partsFunc: partsFunc,
+	}
+}
+
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -1,0 +1,49 @@
+package llm_test
+
+import (
+	"testing"
+
+	"maragu.dev/env"
+	"maragu.dev/is"
+	"maragu.dev/llm"
+)
+
+func TestChatCompleter(t *testing.T) {
+	_ = env.Load(".env.test.local")
+
+	t.Run("can send a streaming chat completion request", func(t *testing.T) {
+		tests := []struct {
+			name string
+			cc   llm.Completer
+		}{
+			{"openai", newOpenAIClient()},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				prompt := llm.Prompt{
+					Model: llm.ModelGPT4oMini,
+					Messages: []llm.Message{
+						{Role: llm.MessageRoleUser, Parts: []llm.MessagePart{llm.TextMessagePart("Hi!")}},
+					},
+					Temperature: llm.Ptr(0.0),
+				}
+
+				res := test.cc.Complete(t.Context(), prompt)
+
+				var text string
+				for part, err := range res.Parts() {
+					text += part.Text()
+					is.NotError(t, err)
+				}
+				is.Equal(t, text, "Hello! How can I assist you today?")
+			})
+		}
+	})
+}
+
+func newOpenAIClient() *llm.OpenAIClient {
+	_ = env.Load(".env.test.local")
+
+	return llm.NewOpenAIClient(llm.NewOpenAIClientOptions{Key: env.GetStringOrDefault("OPENAI_KEY", "")})
+}


### PR DESCRIPTION
The interface is for clients implementing chat completion, preferrably streaming.

The implementation for OpenAI will be pulled out into its own module eventually, see #55.